### PR TITLE
Elemieux/wcag

### DIFF
--- a/d2l-video.js
+++ b/d2l-video.js
@@ -19,6 +19,7 @@ import 'd2l-typography/d2l-typography.js';
 import 'fullscreen-api/fullscreen-api.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import './localize-behavior.js';
+import 'd2l-offscreen/d2l-offscreen.js';
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-video">
@@ -165,7 +166,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 		<fullscreen-api id="fsApi" target="{{ _getFsTarget() }}" fullscreen="{{ isFullscreen }}"></fullscreen-api>
 
 		<div id="container" on-tap="_onContainerTap">
-			<video id="media" controls$="{{ _isMobileSafari() }}" preload="{{ _getPreload(autoLoad) }}" poster="{{ poster }}" on-tap="_onVideoTap" autoplay="{{ _getAutoplay(autoplay) }}" aria-label$="[[localize('VideoPlayer')]]"></video>
+			<video id="media" controls$="{{ _isMobileSafari() }}" preload="{{ _getPreload(autoLoad) }}" poster="{{ poster }}" on-tap="_onVideoTap" autoplay="{{ _getAutoplay(autoplay) }}" aria-label$="[[localize('EvidenceVideoPlayer')]]"></video>
 			<div id="controlBar" hidden$="{{ _isMobileSafari() }}" class="layout horizontal center d2l-typography">
 				<div class="control play-pause-container">
 					<button hidden$="{{ isPlaying }}" on-tap="_playPause" aria-label$="[[localize('Play')]]"><d2l-icon icon="d2l-tier3:play"></d2l-icon></button>
@@ -177,6 +178,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 						<div class="volume-control-container" on-mouseover="_showVolumeControlByHover" on-mouseout="_hideVolumeControlByHover" >
 							<div class="volume-control" on-tap="_onVolumeControlTap">
 								<d2l-seek-bar id="volumeBar" value="40" immediate-value="{{ rawVolume }}" vertical="" aria-label$="[[localize('VolumeBar')]]"></d2l-seek-bar>
+								<d2l-offscreen aria-live="assertive">Volume {{ rawVolume }}</d2l-offscreen>
 							</div>
 						</div>
 					</template>

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -164,7 +164,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 
 		<fullscreen-api id="fsApi" target="{{ _getFsTarget() }}" fullscreen="{{ isFullscreen }}"></fullscreen-api>
 
-		<div id="container" on-tap="_onContainerTap" role="application">
+		<div id="container" on-tap="_onContainerTap">
 			<video id="media" controls$="{{ _isMobileSafari() }}" preload="{{ _getPreload(autoLoad) }}" poster="{{ poster }}" on-tap="_onVideoTap" autoplay="{{ _getAutoplay(autoplay) }}" aria-label$="[[localize('VideoPlayer')]]"></video>
 			<div id="controlBar" hidden$="{{ _isMobileSafari() }}" class="layout horizontal center d2l-typography">
 				<div class="control play-pause-container">

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -164,7 +164,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 
 		<fullscreen-api id="fsApi" target="{{ _getFsTarget() }}" fullscreen="{{ isFullscreen }}"></fullscreen-api>
 
-		<div id="container" on-tap="_onContainerTap">
+		<div id="container" on-tap="_onContainerTap" role="application">
 			<video id="media" controls$="{{ _isMobileSafari() }}" preload="{{ _getPreload(autoLoad) }}" poster="{{ poster }}" on-tap="_onVideoTap" autoplay="{{ _getAutoplay(autoplay) }}" aria-label$="[[localize('VideoPlayer')]]"></video>
 			<div id="controlBar" hidden$="{{ _isMobileSafari() }}" class="layout horizontal center d2l-typography">
 				<div class="control play-pause-container">

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -178,7 +178,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 						<div class="volume-control-container" on-mouseover="_showVolumeControlByHover" on-mouseout="_hideVolumeControlByHover" >
 							<div class="volume-control" on-tap="_onVolumeControlTap">
 								<d2l-seek-bar id="volumeBar" value="40" immediate-value="{{ rawVolume }}" vertical="" aria-label$="[[localize('VolumeBar')]]"></d2l-seek-bar>
-								<d2l-offscreen aria-live="assertive">Volume {{ rawVolume }}</d2l-offscreen>
+								<d2l-offscreen aria-live="assertive">[[localize('VolumeLevel', 'rawVolume', rawVolume)]]</d2l-offscreen>
 							</div>
 						</div>
 					</template>

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.ar = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.de = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -8,8 +8,9 @@ window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2L
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.en = {
 	"Play": "Play",
 	"Pause": "Pause",
+	"Volume": "Volume",
 	"Fullscreen": "Fullscreen",
-	"VideoPlayer": "Video Player",
+	"EvidenceVideoPlayer": "Evidence Video Player",
 	"VolumeBar": "Volume Bar",
 	"SeekBar": "Seek Bar"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -9,6 +9,7 @@ window.D2L.PolymerBehaviors.D2LVideo.LangTerms.en = {
 	"Play": "Play",
 	"Pause": "Pause",
 	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
 	"Fullscreen": "Fullscreen",
 	"EvidenceVideoPlayer": "Evidence Video Player",
 	"VolumeBar": "Volume Bar",

--- a/lang/es.js
+++ b/lang/es.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.es = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.fr = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.ja = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.ko = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/nb.js
+++ b/lang/nb.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.nb = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.nl = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.pt = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.sv = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.tr = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/zh-CN.js
+++ b/lang/zh-CN.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms["zh-cn"] = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/zh-TW.js
+++ b/lang/zh-TW.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms["zh-tw"] = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -6,5 +6,12 @@ window.D2L.PolymerBehaviors.D2LVideo = window.D2L.PolymerBehaviors.D2LVideo || {
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms = window.D2L.PolymerBehaviors.D2LVideo.LangTerms || {};
 
 window.D2L.PolymerBehaviors.D2LVideo.LangTerms.zh = {
-
+	"Play": "Play",
+	"Pause": "Pause",
+	"Volume": "Volume",
+	"VolumeLevel": "Volume {rawVolume}",
+	"Fullscreen": "Fullscreen",
+	"EvidenceVideoPlayer": "Evidence Video Player",
+	"VolumeBar": "Volume Bar",
+	"SeekBar": "Seek Bar"
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@d2l/media-behavior": "Brightspace/d2l-media-behavior#semver:^1",
     "@d2l/seek-bar": "Brightspace/d2l-seek-bar#semver:^1",
+    "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
     "@polymer/iron-range-behavior": "^3.0.0-pre.18",


### PR DESCRIPTION
Added a hidden d2l-offscreen element to read out volume levels for screen reader.
Changed name of player to "Evidence Video Player" for clarity when using a screen reader.
Fixed missing langterm for the volume button.