### PR TITLE
Convert deprecated UI dependencies to core

### DIFF
--- a/d2l-video.js
+++ b/d2l-video.js
@@ -10,21 +10,19 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
-import 'd2l-icons/tier3-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/offscreen/offscreen.js';
+import '@brightspace-ui/core/components/typography/typography.js';
 import '@d2l/media-behavior/d2l-media-behavior.js';
 import '@d2l/seek-bar/d2l-seek-bar.js';
-import 'd2l-typography/d2l-typography.js';
 import 'fullscreen-api/fullscreen-api.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import './localize-behavior.js';
-import 'd2l-offscreen/d2l-offscreen.js';
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 	<template strip-whitespace="">
-		<style is="custom-style" include="iron-flex iron-flex-alignment d2l-typography">
+		<style is="custom-style" include="iron-flex iron-flex-alignment">
 			:host {
 				display: inline-block;
 				position: relative;

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@
 		</script>
 		<script type="module" src="../d2l-video.js"></script>
   </head>
-  <body>
+  <body class="d2l-typography">
 		<d2l-video id="video1" src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" poster="./poster.png" auto-load></d2l-video>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -42,18 +42,14 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
+    "@brightspace-ui/core": "^1.53.0",
     "@d2l/media-behavior": "Brightspace/d2l-media-behavior#semver:^1",
     "@d2l/seek-bar": "Brightspace/d2l-seek-bar#semver:^1",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
     "@polymer/iron-range-behavior": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",
-    "d2l-button": "BrightspaceUI/button#semver:^5",
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
-    "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
-    "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"
   }
 }


### PR DESCRIPTION
## Reasoning
As a part of the `d2l-video` updates, we need some new icons. Since [BrightspaceUI/core](https://github.com/Brightspaceui/core) was never a dependency previously, remove all deprecated UI dependencies and replace with a single dependency on core.

## Testing
Changes tested
- Within the demo page
- Integrated within Portfolio.
  - Running `npm i` for Portfolio with the updated `d2l-video`, old dependencies were removed.
  - Tested the video player in the UI and it worked as expected.
  - <img width="1595" alt="Screen Shot 2020-06-19 at 9 31 05 AM" src="https://user-images.githubusercontent.com/13937038/85143686-aaeaf580-b20f-11ea-8fb7-85ca07cf7aa4.png">
