### PR TITLE
Fix overflow bug with volume container

### DIFF
--- a/d2l-video.js
+++ b/d2l-video.js
@@ -143,7 +143,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 				color: white;
 			}
 
-			.volume-control-container {
+			.volume-control-container .rotation-container {
 				padding: 4px 20px 5px 46px;
 				position: absolute;
 				bottom: 76px;
@@ -268,10 +268,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 					</button>
 					<template is="dom-if" if="{{ volumeControlVisible }}">
 						<div class="volume-control-container" on-mouseover="_showVolumeControlByHover" on-mouseout="_hideVolumeControlByHover" >
-							<div class="volume-control" on-tap="_onVolumeControlTap">
-								<d2l-seek-bar solid id="volumeBar" value="40" immediate-value="{{ rawVolume }}" vertical="" aria-label$="[[localize('VolumeBar')]]"></d2l-seek-bar>
-								<d2l-offscreen aria-live="assertive">[[localize('VolumeLevel', 'rawVolume', rawVolume)]]</d2l-offscreen>
+							<div class="rotation-container">
+								<div class="volume-control" on-tap="_onVolumeControlTap">
+									<d2l-seek-bar solid id="volumeBar" value="40" immediate-value="{{ rawVolume }}" vertical="" aria-label$="[[localize('VolumeBar')]]"></d2l-seek-bar>
+								</div>
 							</div>
+							<d2l-offscreen aria-live="assertive">[[localize('VolumeLevel', 'rawVolume', rawVolume)]]</d2l-offscreen>
 						</div>
 					</template>
 				</div>


### PR DESCRIPTION
## The bug 🐛 
When hovering over the volume container, a scrollbar appears. This bug existed prior to the recent redesign.

## Cause
The volume container is using `d2l-offscreen` to facilitate screen readers. The volume container also uses a 90º rotated component. Since `d2l-offscreen` was being rotated within the component, it placed a 1x1 pixel element 10000px down the page, causing the element to overflow.

## Solution
Move the `d2l-offscreen` component out of the rotation container

## Screenshots

### Scrollbar showing up on hover
![video-volume](https://user-images.githubusercontent.com/13937038/86489419-e74b4500-bd29-11ea-928a-e929b6da77bc.gif)
