### PR TITLE
Fix playback speed controls on small screens

### DIFF
--- a/d2l-video.js
+++ b/d2l-video.js
@@ -169,6 +169,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 
 			#playback-speed-control {
 				color: white;
+				height: 263px;
 				background-color: rgba(0, 0, 0, 0.69);
 				border-radius: 5px 5px 0 0;
 				padding: 2px;
@@ -386,11 +387,15 @@ Polymer({
 		'esc': '_closeControls'
 	},
 
-	ready: function() {
-		const observer = new ResizeObserver(() => {
+	attached: function() {
+		this.observer = new ResizeObserver(() => {
 			this._handleControlHeight();
 		});
-		observer.observe(this);
+		this.observer.observe(this);
+	},
+
+	detached: function() {
+		if (this.observer) this.observer.disconnect();
 	},
 
 	mousemove: function() {
@@ -523,11 +528,7 @@ Polymer({
 	_handleControlHeight: function() {
 		const control = this.shadowRoot.querySelector('#playback-speed-control');
 		if (control) {
-			if (this.offsetHeight < 320) {
-				control.style.height = `${this.offsetHeight - 60}px`;
-			} else {
-				control.style.height = '263px';
-			}
+			control.style.maxHeight = `${this.offsetHeight - 60}px`;
 		}
 	},
 

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -393,7 +393,6 @@ Polymer({
 		observer.observe(this);
 	},
 
-
 	mousemove: function() {
 		this._showControlsTemporary();
 	},

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -9,6 +9,7 @@
 import '@polymer/polymer/polymer-legacy.js';
 
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
+import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
@@ -163,6 +164,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 				bottom: 6px;
 				padding-bottom: 43px;
 				left: -25px;
+				overflow: hidden;
 			}
 
 			#playback-speed-control {
@@ -170,7 +172,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 				background-color: rgba(0, 0, 0, 0.69);
 				border-radius: 5px 5px 0 0;
 				padding: 2px;
-				overflow: hidden;
+				overflow-y: auto;
 			}
 
 			#playback-speed-control button {
@@ -194,6 +196,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 				width: 32px;
 				line-height: 22px;
 				display: inline-block;
+			}
+
+			.playback-speed-container button {
+				font-size: inherit;
+				font-family: inherit;
 			}
 
 			button {
@@ -291,7 +298,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-video">
 							<div role="menu" aria-labelledby="playback-speed-control-toggle" id="playback-speed-control">
 								<dom-repeat items="{{ _playbackSpeeds }}">
 									<template>
-										<button role="menuitem" on-tap="_onPlaybackSpeedControlChanged" value="{{ item }}" aria-label$="[[localize('PlaybackSpeedLabel', 'playbackSpeed', item)]]">[[_playbackSpeedLabel(item)]]</button>
+										<button class="d2l-body-compact" role="menuitem" on-tap="_onPlaybackSpeedControlChanged" value="{{ item }}" aria-label$="[[localize('PlaybackSpeedLabel', 'playbackSpeed', item)]]">[[_playbackSpeedLabel(item)]]</button>
 									</template>
 								</dom-repeat>
 							</div>
@@ -320,6 +327,7 @@ Polymer({
 	behaviors: [
 		window.D2L.MediaBehavior,
 		IronA11yKeysBehavior,
+		IronResizableBehavior,
 		D2L.PolymerBehaviors.D2LVideo.LocalizeBehavior
 	],
 
@@ -377,6 +385,14 @@ Polymer({
 		'space': '_playPause',
 		'f': '_toggleFullscreen',
 		'esc': '_closeControls'
+	},
+
+	ready: function() {
+		this.addEventListener('iron-resize', this.onIronResize.bind(this));
+	},
+			
+	onIronResize: function() {
+		this._handleControlHeight();
 	},
 
 	mousemove: function() {
@@ -498,11 +514,23 @@ Polymer({
 	_showControls: function() {
 		this._controlsVisible = true;
 		this.shadowRoot.querySelector('#controlBar').removeAttribute('hidden');
+		this._handleControlHeight();
 	},
 
 	_hideControls: function() {
 		this._controlsVisible = false;
 		this.shadowRoot.querySelector('#controlBar').setAttribute('hidden', '');
+	},
+
+	_handleControlHeight: function() {
+		const control = this.shadowRoot.querySelector('#playback-speed-control');
+		if (control) {
+			if (this.offsetHeight < 320) {
+				control.style.height = `${this.offsetHeight - 60}px`;
+			} else {
+				control.style.height = '263px';
+			}
+		}
 	},
 
 	_onVideoMouseOver: function() {

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -390,7 +390,7 @@ Polymer({
 	ready: function() {
 		this.addEventListener('iron-resize', this.onIronResize.bind(this));
 	},
-			
+
 	onIronResize: function() {
 		this._handleControlHeight();
 	},

--- a/d2l-video.js
+++ b/d2l-video.js
@@ -9,7 +9,7 @@
 import '@polymer/polymer/polymer-legacy.js';
 
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
-import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
+import ResizeObserver from 'resize-observer-polyfill';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
@@ -327,7 +327,6 @@ Polymer({
 	behaviors: [
 		window.D2L.MediaBehavior,
 		IronA11yKeysBehavior,
-		IronResizableBehavior,
 		D2L.PolymerBehaviors.D2LVideo.LocalizeBehavior
 	],
 
@@ -388,12 +387,12 @@ Polymer({
 	},
 
 	ready: function() {
-		this.addEventListener('iron-resize', this.onIronResize.bind(this));
+		const observer = new ResizeObserver(() => {
+			this._handleControlHeight();
+		});
+		observer.observe(this);
 	},
 
-	onIronResize: function() {
-		this._handleControlHeight();
-	},
 
 	mousemove: function() {
 		this._showControlsTemporary();

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@d2l/seek-bar": "Brightspace/d2l-seek-bar#semver:^1",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
-    "@polymer/iron-range-behavior": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "merge-stream": "^2.0.0",
     "polymer-cli": "^1.9.1",
     "require-dir": "^1.2.0",
+    "resize-observer-polyfill": "^1.5.1",
     "wct-browser-legacy": "^1.0.1"
   },
   "resolutions": {
@@ -47,7 +48,6 @@
     "@d2l/seek-bar": "Brightspace/d2l-seek-bar#semver:^1",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
-    "@polymer/iron-range-behavior": "^3.0.0-pre.18",
     "@polymer/iron-resizable-behavior": "^3.0.1",
     "@polymer/polymer": "^3.0.0",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
     "@polymer/iron-range-behavior": "^3.0.0-pre.18",
+    "@polymer/iron-resizable-behavior": "^3.0.1",
     "@polymer/polymer": "^3.0.0",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@d2l/seek-bar": "Brightspace/d2l-seek-bar#semver:^1",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
-    "@polymer/iron-resizable-behavior": "^3.0.1",
+    "@polymer/iron-range-behavior": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-video",
   "name": "@d2l/video",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",


### PR DESCRIPTION
## Issue
On smaller screens, the playback controls popup would overflow the video, causing the top of the list to be cut off

## Solution
Add scrolling overflow to the menu when the height of the video is too small.
This is achieved with a resize event listener which checks the height of the element and sizes it accordingly.

## Screenshots

### Before - menu overflowing, top elements inaccessible
![overflowing](https://user-images.githubusercontent.com/13937038/87497799-efee2600-c61b-11ea-9684-f392b5f51e94.gif)

### After - scrollable menu
![fixed](https://user-images.githubusercontent.com/13937038/87497803-f1b7e980-c61b-11ea-958a-65f560812923.gif)
